### PR TITLE
Support for upcoming glue 1.3.0 release

### DIFF
--- a/R/aaa.R
+++ b/R/aaa.R
@@ -38,12 +38,18 @@ NULL
 NULL
 
 #' Exporting collapse from glue as glue_collapse
-#' @details See \code{\link[glue]{collapse}} in the \code{glue} package for more details
+#' @details See \code{\link[glue]{glue_collapse}} in the \code{glue} package for more details
 #' @name glue_collapse
 #' @rdname glue_collapse
-#' @param ... arguments passed to \code{glue::collapse}
+#' @param ... arguments passed to \code{glue::glue_collapse}
 #' @export
-glue_collapse <- function(...) glue::collapse(...)
+glue_collapse <- function(...) {
+  if (utils::packageVersion("glue") > "1.2.0") {
+    utils::getFromNamespace("glue_collapse", "glue")(...)
+  } else {
+    utils::getFromNamespace("collapse", "glue")(...)
+  }
+}
 NULL
 
 #' Exporting glue_data from glue

--- a/R/explore.R
+++ b/R/explore.R
@@ -90,7 +90,7 @@ explore <- function(
     }
 
     ## setup regular expression to split variable/function column appropriately
-    rex <- paste0("(.*?)_", glue('({glue::collapse(fun, "$|")}$)'))
+    rex <- paste0("(.*?)_", glue('({glue_collapse(fun, "$|")}$)'))
 
     ## useful answer and comments: http://stackoverflow.com/a/27880388/1974918
     tab <- gather(tab, "variable", "value", !! -(1:length(byvar))) %>%

--- a/man/glue_collapse.Rd
+++ b/man/glue_collapse.Rd
@@ -7,11 +7,11 @@
 glue_collapse(...)
 }
 \arguments{
-\item{...}{arguments passed to \code{glue::collapse}}
+\item{...}{arguments passed to \code{glue::glue_collapse}}
 }
 \description{
 Exporting collapse from glue as glue_collapse
 }
 \details{
-See \code{\link[glue]{collapse}} in the \code{glue} package for more details
+See \code{\link[glue]{glue_collapse}} in the \code{glue} package for more details
 }


### PR DESCRIPTION
`glue::collapse()` has been renamed to `glue::glue_collapse()`, this
provides support for both versions.

I plan to submit glue 1.3.0 to CRAN later this month.