### PR TITLE
More configurable theme; start on Bootstrap 4 support

### DIFF
--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -498,6 +498,7 @@ options(
       windowTitle = "Radiant",
       id = "nav_radiant",
       inverse = TRUE,
+      theme = getOption("radiant.theme"),
       collapsible = TRUE,
       position = "fixed-top",
       tabPanel("Data", withMathJax(), uiOutput("ui_data"))

--- a/inst/app/global.R
+++ b/inst/app/global.R
@@ -398,13 +398,22 @@ navbar_proj <- function(navbar) {
     options(radiant.launch_dir = pdir)
   }
   proj <- tags$span(class = "nav navbar-brand navbar-right", proj)
-  ## based on: https://stackoverflow.com/a/40755608/1974918
-  navbar[[3]][[1]]$children[[1]]$children[[2]] <- htmltools::tagAppendChild(
-    navbar[[3]][[1]]$children[[1]]$children[[2]],
-    proj
-  )
+
+  # Try to insert the project into the navbar
+  # https://stackoverflow.com/a/40755608/1974918
+  # The actual navbar content may be in a different location if {bslib} is used
+  # https://github.com/rstudio/shiny/pull/3236
+  idx <- if (has_bslib_theme()) 4 else 3
+  collapse <- navbar[[idx]][[1]]$children[[1]]$children[[2]]
+  if (isTRUE(grepl("navbar-collapse", collapse$attribs$class))) {
+    navbar[[idx]][[1]]$children[[1]]$children[[2]] <- htmltools::tagAppendChild(collapse, proj)
+  }
 
   navbar
+}
+
+has_bslib_theme <- function() {
+  if (rlang::is_installed("bslib")) bslib::is_bs_theme(getOption("radiant.theme")) else FALSE
 }
 
 if (getOption("radiant.shinyFiles", FALSE)) {

--- a/inst/app/tools/data/view_ui.R
+++ b/inst/app/tools/data/view_ui.R
@@ -273,5 +273,6 @@ observeEvent(input$view_report, {
 })
 
 bslib_current_version <- function() {
-  if (rlang::is_installed("bslib")) bslib::theme_version(bslib::bs_current_theme())
+  if (rlang::is_installed("bslib"))
+    bslib::theme_version(getOption("radiant.theme"))
 }

--- a/inst/app/tools/data/view_ui.R
+++ b/inst/app/tools/data/view_ui.R
@@ -109,7 +109,7 @@ output$dataviewer <- DT::renderDataTable({
       # extension = "KeyTable",
       escape = FALSE,
       # editable = TRUE,
-      style = "bootstrap",
+      style = if ("4" %in% bslib_current_version()) "bootstrap4" else "bootstrap",
       options = list(
         stateSave = TRUE, ## maintains state
         searchCols = lapply(r_state$dataviewer_search_columns, function(x) list(search = x)),
@@ -271,3 +271,7 @@ download_handler(id = "dl_view_tab", fun = dl_view_tab, fn = function() paste0(i
 observeEvent(input$view_report, {
   update_report(cmd = .viewcmd(), outputs = NULL, figs = FALSE)
 })
+
+bslib_current_version <- function() {
+  if (rlang::is_installed("bslib")) bslib::theme_version(bslib::bs_current_theme())
+}

--- a/inst/app/www/style.css
+++ b/inst/app/www/style.css
@@ -113,6 +113,7 @@ textarea, select {
   left: 0;
   right: 50%;
   padding-right: 10px;
+  margin-top: 1rem;
 }
 
 /* from: https://github.com/swarm-lab/editR/blob/master/inst/app/www/editR.css */
@@ -124,12 +125,13 @@ textarea, select {
   right: 0;
   padding-left: 10px;
   overflow-y: scroll;
+  margin-top: 1rem;
 }
 
 /* Needed in combination with navbarPage with fixed-top */
 /* based on https://stackoverflow.com/a/19231861/1974918 */
 body {
-  padding-top: 55px;
+  padding-top: 65px;
 }
 
 .navbar {


### PR DESCRIPTION
This PR adds a new option, `radiant.theme`, which makes it possible to set a custom theme (without needing to know about the other defaults behind `radiant.nav_ui`).

The other CSS changes make things look slightly better when using Bootstrap 4 via the new `{bslib}` package. See also https://github.com/radiant-rstats/radiant.basics/pull/2 which adds better support for Bootstrap 4 in `{radiant.basics}`.

```r
library(radiant)
# remotes::install_github("rstudio/bslib")
opts <- options(radiant.theme = bslib::bs_theme(version = 4))
shiny::onStop(function() options(opts))
shiny::shinyAppDir(system.file("app", package = "radiant"))
```