### PR TITLE
Disambiguate is_empty to point to radiant.data::is_empty

### DIFF
--- a/inst/app/tools/app/report_rmd.R
+++ b/inst/app/tools/app/report_rmd.R
@@ -421,7 +421,7 @@ rmd_knitted <- eventReactive(report_rmd$report != 1, {
           report <- cnt$content
         }
       } else if (!is_empty(input$rmd_edit)) {
-        if (!is_empty(input$rmd_edit_selection, "")) {
+        if (!radiant.data::is_empty(input$rmd_edit_selection, "")) {
           report <- input$rmd_edit_selection
         } else if (!is_empty(input$rmd_edit_hotkey$line, "") && report_rmd$knit_button == 0) {
           report <- input$rmd_edit_hotkey$line


### PR DESCRIPTION
In /inst/app/tools/app/report_rmd.R. Fixes error caused by masking order

Calling library(tidyverse) in an .rmd inside radiant is sufficient to change the masking order and break .rmd rendering.