### PR TITLE
Move arrow to Suggests to appease CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ Depends:
 Imports:
     tibble (>= 1.4.2),
     rlang (>= 0.4.10),
-    arrow (>= 12.0.1),
     broom (>= 0.5.2),
     car (>= 3.0-0),
     knitr (>= 1.20),
@@ -53,6 +52,7 @@ Suggests:
     DBI (>= 0.7),
     RSQLite (>= 2.0),
     RPostgres (>= 1.4.4),
+    arrow (>= 12.0.1),
     webshot (>= 0.5.0), 
     testthat (>= 2.0.0),
     pkgdown (>= 1.1.0)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,6 +56,8 @@ Suggests:
     webshot (>= 0.5.0), 
     testthat (>= 2.0.0),
     pkgdown (>= 1.1.0)
+Additional_repositories:
+    https://p3m.dev/cran/2024-02-02
 URL: 
     https://github.com/radiant-rstats/radiant.data/, 
     https://radiant-rstats.github.io/radiant.data/,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# radiant.data 1.6.4
+
+* Move arrow from "Imports" to "Suggests" due to arrow archival on CRAN
+
 # radiant.data 1.6.3
 
 * Require shiny 1.8.0. This fixes a bug in the shiny 1.7 versions that caused issues with all radiant packages.


### PR DESCRIPTION
Related to https://github.com/apache/arrow/issues/39806. Since it's not clear that we'll be able to resolve everything with CRAN before February 9, this PR moves arrow from Imports to Suggests.  This will prevent your checks failing on CRAN due to arrow's potential acrhival, but if we don’t get removed, or when we do get back on CRAN, you can revert this.